### PR TITLE
Remove duplicate httpx requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,6 @@ opentelemetry-sdk==1.21.0
 # Testing
 pytest==7.4.3
 pytest-asyncio==0.21.1
-httpx==0.25.2
 
 # Utils
 python-dotenv==1.0.0


### PR DESCRIPTION
## Summary
- drop redundant httpx entry from testing requirements, leaving a single httpx==0.25.2 under HTTP & Async
- ensure requirements.txt ends with a newline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68962fec5934832cb4196113ec21c802